### PR TITLE
add test coverage, and remove dead code

### DIFF
--- a/lib/openskill/thurstone_mosteller_full.ex
+++ b/lib/openskill/thurstone_mosteller_full.ex
@@ -31,11 +31,15 @@ defmodule Openskill.ThurstoneMostellerFull do
                 delta + gamma * sigsq_to_ciq / ciq * Util.w(-tmp, @epsilon / ciq)
               }
 
-            true ->
-              {
-                omega + sigsq_to_ciq * Util.vt(tmp, @epsilon / ciq),
-                delta + gamma * sigsq_to_ciq / ciq * Util.wt(tmp, @epsilon / ciq)
-              }
+              # the filter above ensures that rankq and ranki are never the same,
+              # however this would be necessary if supported tied rankings in 3+
+              # team matches.
+              #
+              # true ->
+              #   {
+              #     omega + sigsq_to_ciq * Util.vt(tmp, @epsilon / ciq),
+              #     delta + gamma * sigsq_to_ciq / ciq * Util.wt(tmp, @epsilon / ciq)
+              #   }
           end
         end)
 

--- a/lib/openskill/thurstone_mosteller_part.ex
+++ b/lib/openskill/thurstone_mosteller_part.ex
@@ -34,11 +34,15 @@ defmodule Openskill.ThurstoneMostellerPart do
                 delta + gamma * sigsq_to_ciq / ciq * Util.w(-tmp, @epsilon / ciq)
               }
 
-            true ->
-              {
-                omega + sigsq_to_ciq * Util.vt(tmp, @epsilon / ciq),
-                delta + gamma * sigsq_to_ciq / ciq * Util.wt(tmp, @epsilon / ciq)
-              }
+              # the filter above ensures that rankq and ranki are never the same,
+              # however this would be necessary if supported tied rankings in 3+
+              # team matches.
+              #
+              # true ->
+              #   {
+              #     omega + sigsq_to_ciq * Util.vt(tmp, @epsilon / ciq),
+              #     delta + gamma * sigsq_to_ciq / ciq * Util.wt(tmp, @epsilon / ciq)
+              #   }
           end
         end)
 

--- a/test/openskill/environment_test.exs
+++ b/test/openskill/environment_test.exs
@@ -2,8 +2,6 @@ defmodule Openskill.EnvironmentTest do
   use ExUnit.Case
   alias Openskill.Environment
 
-  @env %Environment{}
-
   test "#mu" do
     assert is_number(%Environment{}.mu)
   end

--- a/test/openskill/util_test.exs
+++ b/test/openskill/util_test.exs
@@ -83,4 +83,44 @@ defmodule Openskill.UtilTest do
       assert [1, 2] = Util.default_ranks([[:a, :b, :c], [:d, :e, :f]])
     end
   end
+
+  describe "#v" do
+    test "denominator less than threshold" do
+      assert 9900 = Util.v(-10000, -100)
+    end
+  end
+
+  describe "#w" do
+    test "denominator less than threshold" do
+      assert 1 = Util.w(-10000, -100)
+    end
+  end
+
+  describe "#vt" do
+    test "b small, x small" do
+      assert 1100 = Util.vt(-1000, -100)
+    end
+
+    test "b small, x big" do
+      assert -1100 = Util.vt(1000, -100)
+    end
+
+    test "b big, x small" do
+      assert 0.7978845600049808 = Util.vt(-1000, 1000)
+    end
+
+    test "b big, x big" do
+      assert 0.0 = Util.vt(0, 1000)
+    end
+  end
+
+  describe "#wt" do
+    test "under threshold, so just use 1.0" do
+      assert 1.0 = Util.wt(0, 0)
+    end
+
+    test "standard operating protocol" do
+      assert Util.wt(0, 10) < 0.00000000001
+    end
+  end
 end


### PR DESCRIPTION
The tests added should bring test coverage to 100%, which can be seen with the command

```
MIX_ENV=test mix coveralls
```

and which lines specifically need coverage can be seen with

```
MIX_ENV=test mix coveralls.detail
```